### PR TITLE
Add support for stopping persistence to prepare for shutdown.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vuex-persist",
-  "version": "3.1.3",
+  "name": "@propelinc/vuex-persistence",
+  "version": "3.1.3-rc1",
   "description": "A Vuex persistence plugin in Typescript",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -15,7 +15,7 @@
   "types": "dist/types/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/championswimmer/vuex-persist.git"
+    "url": "git+https://github.com/propelinc/vuex-persist.git"
   },
   "scripts": {
     "doc:clean": "rimraf docs",
@@ -49,9 +49,9 @@
   "author": "Arnav Gupta <championswimmer@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/championswimmer/vuex-persist/issues"
+    "url": "https://github.com/propelinc/vuex-persist/issues"
   },
-  "homepage": "https://github.com/championswimmer/vuex-persist#readme",
+  "homepage": "https://github.com/propelinc/vuex-persist#readme",
   "devDependencies": {
     "@types/chai": "^4.1.4",
     "@types/lodash": "^4.6.4",
@@ -79,5 +79,9 @@
   },
   "peerDependencies": {
     "vuex": ">=2.5"
+  },
+  "directories": {
+    "doc": "docs",
+    "test": "test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@propelinc/vuex-persistence",
-  "version": "3.1.3-rc2",
+  "name": "@propelinc/vuex-persist",
+  "version": "3.1.3-propel",
   "description": "A Vuex persistence plugin in Typescript",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@propelinc/vuex-persistence",
-  "version": "3.1.3-rc1",
+  "version": "3.1.3-rc2",
   "description": "A Vuex persistence plugin in Typescript",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/SimplePromiseQueue.ts
+++ b/src/SimplePromiseQueue.ts
@@ -9,7 +9,7 @@ export default class SimplePromiseQueue {
     return Promise.resolve()
   }
 
-  private flushQueue() {
+  public flushQueue() {
     this._flushing = true
 
     const chain = (): Promise<void> | void => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,7 @@ export class VuexPersistence<S> implements PersistOptions<S> {
             store.replaceState(merge(store.state, savedState || {}, this.mergeOption) as S)
           }
           this.subscriber(store)((mutation: MutationPayload, state: S) => {
-            if (this.filter(mutation)) {
+            if (!this.shuttingDown && this.filter(mutation)) {
               this._mutex.enqueue(
                 this.saveState(this.key, this.reducer(state), this.storage) as Promise<void>
               )

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,11 +32,17 @@ export class VuexPersistence<S> implements PersistOptions<S> {
    */
   public plugin: Plugin<S>
   /**
+   * The plugin function that can be to accepting more writes.
+   */
+  public prepareShutdown: () => Promise<void>
+  /**
    * A mutation that can be used to restore state
    * Helpful if we are running in strict mode
    */
   public RESTORE_MUTATION: Mutation<S>
   public subscribed: boolean
+
+  private shuttingDown: boolean
 
   // tslint:disable-next-line:variable-name
   private _mutex = new SimplePromiseQueue()
@@ -52,6 +58,7 @@ export class VuexPersistence<S> implements PersistOptions<S> {
     this.key = ((options.key != null) ? options.key : 'vuex')
 
     this.subscribed = false
+    this.shuttingDown = false
     this.supportCircular = options.supportCircular || false
     if (this.supportCircular) {
       FlattedJSON = require('flatted')
@@ -194,6 +201,11 @@ export class VuexPersistence<S> implements PersistOptions<S> {
           this.subscribed = true
         })
       }
+
+      this.prepareShutdown = () => {
+        this.shuttingDown = true;
+        return this._mutex.flushQueue();
+      }
     } else {
 
       /**
@@ -252,12 +264,17 @@ export class VuexPersistence<S> implements PersistOptions<S> {
         }
 
         this.subscriber(store)((mutation: MutationPayload, state: S) => {
-          if (this.filter(mutation)) {
+          if (!this.shuttingDown && this.filter(mutation)) {
             this.saveState(this.key, this.reducer(state), this.storage)
           }
         })
 
         this.subscribed = true
+      }
+
+      this.prepareShutdown = () => {
+        this.shuttingDown = true;
+        return Promise.resolve();
       }
     }
   }


### PR DESCRIPTION
Adds a method that stops accepting new writes and waits for all existing writes to finish. This allows us to ensure that the store is persisted before restarting the app.