### PR TITLE
Make the async queue a queue

### DIFF
--- a/src/SimplePromiseQueue.ts
+++ b/src/SimplePromiseQueue.ts
@@ -1,10 +1,10 @@
 // tslint:disable: variable-name
 export default class SimplePromiseQueue {
-  private readonly _queue: Array<Promise<void>> = []
+  private readonly _queue: Array<() => Promise<void>> = []
   private _flushing = false
 
-  public enqueue(promise: Promise<void>) {
-    this._queue.push(promise)
+  public enqueue(task: () => Promise<void>) {
+    this._queue.push(task)
     if (!this._flushing) { return this.flushQueue() }
     return Promise.resolve()
   }
@@ -15,7 +15,7 @@ export default class SimplePromiseQueue {
     const chain = (): Promise<void> | void => {
       const nextTask = this._queue.shift()
       if (nextTask) {
-        return nextTask.then(chain)
+        return nextTask().then(chain)
       } else {
         this._flushing = false
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,24 +88,26 @@ export class VuexPersistence<S> implements PersistOptions<S> {
      * How this works is -
      *  1. If there is options.reducer function, we use that, if not;
      *  2. We check options.modules;
-     *    1. If there is no options.modules array, we use entire state in reducer
-     *    2. Otherwise, we create a reducer that merges all those state modules that are
+     *    1a. If there is no options.modules array, we use entire state in reducer
+     *    1b. If writes are async, we clone the state so each saveState call in the queue has its
+     *        own caopy of the state.
+     *    2.  Otherwise, we create a reducer that merges all those state modules that are
      *        defined in the options.modules[] array
      * @type {((state: S) => {}) | ((state: S) => S) | ((state: any) => {})}
      */
-    this.reducer = (
-      (options.reducer != null)
-        ? options.reducer
-        : (
-          (options.modules == null)
-            ? ((state: S) => state)
-            : (
-              (state: any) =>
-                (options!.modules as string[]).reduce((a, i) =>
-                  merge(a, { [i]: state[i] }, this.mergeOption), {/* start empty accumulator*/ })
-            )
-        )
-    )
+    if (options.reducer != null) {
+      this.reducer = options.reducer
+    } else if (options.modules == null) {
+      if (options.asyncStorage) {
+        this.reducer = (state: S) => merge({}, state, this.mergeOption)
+      } else {
+        this.reducer = (state: S) => state
+      }
+    } else {
+      this.reducer = (state: any) =>
+        (options!.modules as string[]).reduce((a, i) =>
+          merge(a, { [i]: state[i] }, this.mergeOption), {/* start empty accumulator*/ })
+    }
 
     this.filter = options.filter || ((mutation) => true)
 
@@ -193,8 +195,9 @@ export class VuexPersistence<S> implements PersistOptions<S> {
           }
           this.subscriber(store)((mutation: MutationPayload, state: S) => {
             if (!this.shuttingDown && this.filter(mutation)) {
+              const reducedState = this.reducer(state)
               this._mutex.enqueue(
-                this.saveState(this.key, this.reducer(state), this.storage) as Promise<void>
+                async () => await this.saveState(this.key, reducedState, this.storage)
               )
             }
           })

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,11 +88,11 @@ export class VuexPersistence<S> implements PersistOptions<S> {
      * How this works is -
      *  1. If there is options.reducer function, we use that, if not;
      *  2. We check options.modules;
-     *    1a. If there is no options.modules array, we use entire state in reducer
-     *    1b. If writes are async, we clone the state so each saveState call in the queue has its
-     *        own caopy of the state.
-     *    2.  Otherwise, we create a reducer that merges all those state modules that are
-     *        defined in the options.modules[] array
+     *    1. If there is no options.modules array, we use entire state in reducer. For the async
+     *       storage case we clone the state so each saveState call in the save queue has its
+     *       own copy of the state.
+     *    2. Otherwise, we create a reducer that merges all those state modules that are
+     *       defined in the options.modules[] array
      * @type {((state: S) => {}) | ((state: S) => S) | ((state: any) => {})}
      */
     if (options.reducer != null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,26 +88,24 @@ export class VuexPersistence<S> implements PersistOptions<S> {
      * How this works is -
      *  1. If there is options.reducer function, we use that, if not;
      *  2. We check options.modules;
-     *    1. If there is no options.modules array, we use entire state in reducer. For the async
-     *       storage case we clone the state so each saveState call in the save queue has its
-     *       own copy of the state.
+     *    1. If there is no options.modules array, we use entire state in reducer
      *    2. Otherwise, we create a reducer that merges all those state modules that are
-     *       defined in the options.modules[] array
+     *        defined in the options.modules[] array
      * @type {((state: S) => {}) | ((state: S) => S) | ((state: any) => {})}
      */
-    if (options.reducer != null) {
-      this.reducer = options.reducer
-    } else if (options.modules == null) {
-      if (options.asyncStorage) {
-        this.reducer = (state: S) => merge({}, state, this.mergeOption)
-      } else {
-        this.reducer = (state: S) => state
-      }
-    } else {
-      this.reducer = (state: any) =>
-        (options!.modules as string[]).reduce((a, i) =>
-          merge(a, { [i]: state[i] }, this.mergeOption), {/* start empty accumulator*/ })
-    }
+    this.reducer = (
+      (options.reducer != null)
+        ? options.reducer
+        : (
+          (options.modules == null)
+            ? ((state: S) => state)
+            : (
+              (state: any) =>
+                (options!.modules as string[]).reduce((a, i) =>
+                  merge(a, { [i]: state[i] }, this.mergeOption), {/* start empty accumulator*/ })
+            )
+        )
+    )
 
     this.filter = options.filter || ((mutation) => true)
 
@@ -195,9 +193,12 @@ export class VuexPersistence<S> implements PersistOptions<S> {
           }
           this.subscriber(store)((mutation: MutationPayload, state: S) => {
             if (!this.shuttingDown && this.filter(mutation)) {
-              const reducedState = this.reducer(state)
+              // We clone the reduced state to snapshot it before enqueuing the save. Otherwise
+              // the save may be modified before the save task runs and then the wrong state
+              // is saved.
+              const clonedState = merge({}, this.reducer(state), 'replaceArrays')
               this._mutex.enqueue(
-                async () => await this.saveState(this.key, reducedState, this.storage)
+                () => this.saveState(this.key, clonedState, this.storage) as Promise<Void>
               )
             }
           })

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,7 @@ export class VuexPersistence<S> implements PersistOptions<S> {
               // is saved.
               const clonedState = merge({}, this.reducer(state), 'replaceArrays')
               this._mutex.enqueue(
-                () => this.saveState(this.key, clonedState, this.storage) as Promise<Void>
+                () => this.saveState(this.key, clonedState, this.storage) as Promise<void>
               )
             }
           })

--- a/test/vuex-async-queue.spec.ts
+++ b/test/vuex-async-queue.spec.ts
@@ -1,0 +1,78 @@
+import { expect } from 'chai'
+import Vue from 'vue'
+import { Store } from 'vuex'
+import Vuex from 'vuex'
+import VuexPersistence from '..'
+
+Vue.use(Vuex)
+
+class SaveWaiter {
+  ready: Promise<void>
+  done: Promise<void>
+  resolveReady!: () => void
+  resolveDone!: () => void
+
+  constructor() {
+    this.ready = new Promise((resolve) => { this.resolveReady = resolve })
+    this.done = new Promise((resolve) => { this.resolveDone = resolve })
+  }
+}
+
+const KEY = 'key'
+const storage: Record<string, any> = {}
+const saveWaiters = [new SaveWaiter(), new SaveWaiter()]
+let saveCount = 0
+const vuexPersist = new VuexPersistence({
+  key: KEY,
+  asyncStorage: true,
+  restoreState: async (key) => storage[key],
+  saveState: async (key, state) => {
+    const saveWaiter = saveWaiters[saveCount]
+    saveCount++
+
+    await saveWaiter.ready
+    storage[key] = state
+    saveWaiter.resolveDone()
+  }
+})
+
+const store = new Store<any>({
+  state: {
+    dog: {
+      barks: 0
+    },
+    cat: {
+      mews: 0
+    }
+  },
+  mutations: {
+    dogBark(state) {
+      state.dog.barks++
+    },
+    catMew(state) {
+      state.cat.mews++
+    }
+  },
+  plugins: [vuexPersist.plugin]
+})
+
+describe('Storage: Custom/Async; Test: queue order', () => {
+  it('should wait for the previous save to finish before saving', async () => {
+    store.commit('dogBark')
+    store.commit('catMew')
+
+    // Make the second saveWaiter ready first. This should do nothing, because the write sits in
+    // the queue behind the first write. The await here is needed to make the expect fail if
+    // saveState has already started execution by making the promise in saveState resolve.
+    saveWaiters[1].resolveReady()
+    await saveWaiters[1].ready
+    expect(storage[KEY]).not.to.exist
+
+    saveWaiters[0].resolveReady()
+    await saveWaiters[0].done
+    expect(storage[KEY]).to.deep.equal({ dog: { barks: 1 }, cat: { mews: 0 }})
+
+    await saveWaiters[1].done
+    expect(storage[KEY]).to.deep.equal({ dog: { barks: 1 }, cat: { mews: 1 }})
+  })
+})


### PR DESCRIPTION
Right now all promises are started immediately, so the writes can happen in the wrong order. This enforces the order of the writes by making each item in the queue a function which we only execute when it reaches the front of the queue. We also modify the default reducer to make a copy of the state, so each saveState call will have a snapshot of the state instead of the global object that can be modified.