### PR TITLE
Rename prepareShutdown and have it wait for all writes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@propelinc/vuex-persist",
-  "version": "3.1.3-propel",
+  "name": "vuex-persist",
+  "version": "3.1.3-propel.2",
   "description": "A Vuex persistence plugin in Typescript",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/SimplePromiseQueue.ts
+++ b/src/SimplePromiseQueue.ts
@@ -1,25 +1,26 @@
 // tslint:disable: variable-name
 export default class SimplePromiseQueue {
   private readonly _queue: Array<() => Promise<void>> = []
-  private _flushing = false
+  private _runner: Promise<void> | null = null
 
   public enqueue(task: () => Promise<void>) {
     this._queue.push(task)
-    if (!this._flushing) { return this.flushQueue() }
-    return Promise.resolve()
+    this.join()
   }
 
-  public flushQueue() {
-    this._flushing = true
-
-    const chain = (): Promise<void> | void => {
-      const nextTask = this._queue.shift()
-      if (nextTask) {
-        return nextTask().then(chain)
-      } else {
-        this._flushing = false
+  public async join(): Promise<void> {
+    const runner = async () => {
+      while (this._queue.length) {
+        const nextTask = this._queue.shift()!
+        await nextTask()
       }
     }
-    return Promise.resolve(chain())
+
+    if (this._runner) {
+      return await this._runner
+    }
+    this._runner = runner()
+    await this._runner
+    this._runner = null
   }
 }

--- a/src/SimplePromiseQueue.ts
+++ b/src/SimplePromiseQueue.ts
@@ -5,15 +5,16 @@ export default class SimplePromiseQueue {
 
   public enqueue(task: () => Promise<void>) {
     this._queue.push(task)
-    this.join()
+    this.flushQueue()
   }
 
-  public async join(): Promise<void> {
+  public async flushQueue(): Promise<void> {
     const runner = async () => {
       while (this._queue.length) {
         const nextTask = this._queue.shift()!
         await nextTask()
       }
+      this._runner = null
     }
 
     if (this._runner) {
@@ -21,6 +22,5 @@ export default class SimplePromiseQueue {
     }
     this._runner = runner()
     await this._runner
-    this._runner = null
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,7 @@ export class VuexPersistence<S> implements PersistOptions<S> {
         })
       }
 
-      this.flushWriteQueue = async () => await this._writeQueue.join()
+      this.flushWriteQueue = async () => await this._writeQueue.flushQueue()
     } else {
 
       /**


### PR DESCRIPTION
This lets an application wait for all writes to the storage to finish before continuing. For example, we may want to wait to save state before leaving a page. Previously, `prepareShutdown` will wait for writes, but also prevents new writes from occurring which can cause data loss.