### PR TITLE
Update deepToRaw function to handle types serialized by localForage.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@propelinc/vuex-persist",
-  "version": "3.1.3-propel.4-alpha-04",
+  "version": "3.1.3-propel.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@propelinc/vuex-persist",
-      "version": "3.1.3-propel.4-alpha-04",
+      "version": "3.1.3-propel.5",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@propelinc/vuex-persist",
-  "version": "3.1.3-propel.4",
+  "version": "3.1.3-propel.5",
   "description": "A Vuex persistence plugin in Typescript",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,13 +4,18 @@ import { toRaw } from 'vue'
 export type MergeOptionType = 'replaceArrays' | 'concatArrays'
 
 function deepToRaw(value: any): any {
-  if (Array.isArray(value)) {
-    return toRaw(value).map(deepToRaw);
+  if (value === null || typeof value !== 'object') {
+    return value;
   }
-  if (typeof value === 'object' && value !== null) {
-    return Object.fromEntries(Object.entries(value).map(([key, value]) => ([key, deepToRaw(value)])))
+  const raw = toRaw(value);
+  // NOTE(ram): Preserve special object types that localForage can serialize.
+  if (raw instanceof Date || raw instanceof Blob || raw instanceof ArrayBuffer) {
+    return raw;
   }
-  return value;
+  if (Array.isArray(raw)) {
+    return raw.map(deepToRaw);
+  }
+  return Object.fromEntries(Object.entries(raw).map(([k, v]) => [k, deepToRaw(v)]));
 }
 
 const options: {[k in MergeOptionType]: deepmerge.Options} = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import { toRaw } from 'vue'
 
 export type MergeOptionType = 'replaceArrays' | 'concatArrays'
 
-function deepToRaw(value: any): any {
+export function deepToRaw(value: any): any {
   if (value === null || typeof value !== 'object') {
     return value;
   }


### PR DESCRIPTION
This fixes a vue 3 bug related to storing dates. Dates are handled by the localForage serializer and worked in vue 2 but started breaking in vue 3 with the deepToRaw change as the Date object is replaced by an empty object by the current implementation. This PR updates the deepToRaw function to handle Dates correctly.